### PR TITLE
script: update.py Fix compatibility with Windows

### DIFF
--- a/script/update.py
+++ b/script/update.py
@@ -54,6 +54,7 @@ for asset in rel["assets"]:
 
       file_zip = ZipFile(file_mem)
       for f in [def_txt, def_reg, chs_txt, chs_reg]:
-        with file_zip.open(str(rootdir / f), "r") as fin:
+        f.parent.mkdir(parents=True, exist_ok=True)
+        with file_zip.open((rootdir / f).as_posix(), "r") as fin:
           with open(str(f), "wb") as fout:
             fout.write(fin.read())


### PR DESCRIPTION
# Describe the bug

Python enforces strict rules between \ and / original code overlooked this distinction. Module reads ZIP with Unix path ( / ) but extraction ZIP uses Windows path ( \ ) in Windows, causing error

# Proposed changes

fix:Use as_posix for cross-platform ZIP path resolution
